### PR TITLE
Revert "Zuk: Force Enable dt2w"

### DIFF
--- a/rootdir/etc/init.qcom.rc
+++ b/rootdir/etc/init.qcom.rc
@@ -279,9 +279,6 @@ on boot
     chown system system /sys/devices/soc/soc:fpc1020/utouch_disable
     chmod 0660 /sys/devices/soc/soc:fpc1020/utouch_disable
 
-    #dt2w
-    write /sys/devices/virtual/touch/tp_dev/gesture_on 1
-
     #added touch gesture wake node permission
     chown system system /sys/devices/virtual/touch/tp_dev/gesture_on
     chmod 0660 /sys/devices/virtual/touch/tp_dev/gesture_on


### PR DESCRIPTION
This reverts commit 5003e437ed0abd5cfe193741554dd3b040b63368.

This fixes DT2W working even after being disabled from display settings